### PR TITLE
Fix minor issues with tower installer

### DIFF
--- a/roles/ansible-tower-install/defaults/main.yml
+++ b/roles/ansible-tower-install/defaults/main.yml
@@ -6,7 +6,7 @@
 ############################################################
 
 # Working location for installation files
-tower_working_location: "/root/"
+tower_working_location: "/var/tmp"
 
 # Tower variables
 tower_admin_password: "password"

--- a/roles/ansible-tower-install/tasks/tower_install.yml
+++ b/roles/ansible-tower-install/tasks/tower_install.yml
@@ -32,6 +32,7 @@
 
 # Run the Setup
 - name: "[Tower] Run the Ansible Tower Setup Program"
+  become: true
   command: ./setup.sh
   args:
     chdir: "{{ tower_setup_dir }}"

--- a/tower_setup/cluster_inventory
+++ b/tower_setup/cluster_inventory
@@ -5,7 +5,7 @@ localhost
 tower_release_version="3.7.1-1"
 tower_admin_password="r3dh4t!"
 tower_cert_location="/var/tmp/tower.cert"
-tower_cert_location="/var/tmp/tower.key"
+tower_cert_key_location="/var/tmp/tower.key"
 
 [tower]
 tower1.example.com

--- a/tower_setup/single_node_inventory
+++ b/tower_setup/single_node_inventory
@@ -5,7 +5,7 @@ tower.example.com
 tower_release_version="3.7.1-1"
 tower_admin_password="r3dh4t!"
 tower_cert_location="/var/tmp/tower.cert"
-tower_cert_location="/var/tmp/tower.key"
+tower_cert_key_location="/var/tmp/tower.key"
 tower_single_node=true
 
 [tower]


### PR DESCRIPTION
After fully running through this code I realised there were a couple of problems:

- By default we weren't set to become, so we couldn't have the default working location as /root
- Running setup.sh failed when not set to become
- Mistake in inventories where `tower_cert_key_location` was not set, but `tower_cert_location` was set twice