### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/minikube.yml
+++ b/.github/workflows/minikube.yml
@@ -59,7 +59,7 @@ jobs:
         run: minikube kubectl get pods
 
       - name: Set service url
-        run: echo '::set-output name=SERVICEURL::$(minikube service awx-service --url)'
+        run: echo 'SERVICEURL=$(minikube service awx-service --url)' >> $GITHUB_OUTPUT
         id: service-url
 
       - name: Display service url


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


