### PR TITLE
Fix order of roles to fix dependency over notifications

### DIFF
--- a/playbooks/controller_config.yml
+++ b/playbooks/controller_config.yml
@@ -87,6 +87,11 @@
         name: infra.controller_configuration.organizations
       when: controller_organizations | length is not match('0')
 
+    - name: Include Notification role
+      ansible.builtin.include_role:
+        name: infra.controller_configuration.notification_templates
+      when: controller_notifications | length is not match('0')
+
     - name: Include projects role
       ansible.builtin.include_role:
         name: infra.controller_configuration.projects
@@ -135,11 +140,6 @@
       ansible.builtin.include_role:
         name: infra.controller_configuration.schedules
       when: controller_schedules | length is not match('0')
-
-    - name: Include Notification role
-      ansible.builtin.include_role:
-        name: infra.controller_configuration.notification_templates
-      when: controller_notifications | length is not match('0')
 
     - name: Include roles role
       ansible.builtin.include_role:

--- a/playbooks/install_configure.yml
+++ b/playbooks/install_configure.yml
@@ -162,6 +162,11 @@
         name: infra.controller_configuration.organizations
       when: controller_organizations | length is not match('0')
 
+    - name: Include Notification role
+      ansible.builtin.include_role:
+        name: infra.controller_configuration.notification_templates
+      when: controller_notifications | length is not match('0')
+
     - name: Include projects role
       ansible.builtin.include_role:
         name: infra.controller_configuration.projects
@@ -210,11 +215,6 @@
       ansible.builtin.include_role:
         name: infra.controller_configuration.schedules
       when: controller_schedules | length is not match('0')
-
-    - name: Include Notification role
-      ansible.builtin.include_role:
-        name: infra.controller_configuration.notification_templates
-      when: controller_notifications | length is not match('0')
 
     - name: Include roles role
       ansible.builtin.include_role:


### PR DESCRIPTION
Notifications can be added to projects, job_templates and probably many others. To prevent failure we have to set them first.