### PR TITLE
Add group roles to replace group permissions

### DIFF
--- a/group_vars/all/ah_group_roles.yml
+++ b/group_vars/all/ah_group_roles.yml
@@ -1,7 +1,6 @@
 ---
 # Documentation: https://github.com/ansible/galaxy_collection/blob/devel/roles/group_roles/README.md
-ah_group_roles:
-
+ah_group_roles: []
   # - state: present
   #   groups:
   #     - foo

--- a/group_vars/all/ah_group_roles.yml
+++ b/group_vars/all/ah_group_roles.yml
@@ -1,0 +1,14 @@
+---
+# Documentation: https://github.com/ansible/galaxy_collection/blob/devel/roles/group_roles/README.md
+ah_group_roles:
+
+  # - state: present
+  #   groups:
+  #     - foo
+  #   role_list:
+  #     - roles:
+  #         - galaxy.execution_environment_namespace_owner
+  #       targets:
+  #         execution_environments:
+  #           - bar
+...

--- a/group_vars/all/ah_groups.yml
+++ b/group_vars/all/ah_groups.yml
@@ -1,7 +1,8 @@
 ---
-ah_groups: []
-  # Currently not working
-  # - name: admin
-  #   perms: all
-  #   state: present
+# Role permissions using the 'perms' option is deprecated and will be removed
+# in galaxy_collection 3.0.0.Instead, set the group's roles in
+# groups_vars/all/ah_group_roles.yml
+ah_groups:
+  - name: admin
+    state: present
 ...

--- a/playbooks/hub_config.yml
+++ b/playbooks/hub_config.yml
@@ -34,6 +34,11 @@
         name: infra.ah_configuration.group
       when: ah_groups | length is not match('0')
 
+    - name: Include group_roles role
+      ansible.builtin.include_role:
+        name: infra.ah_configuration.group_roles
+      when: ah_group_roles | length is not match('0')
+
     - name: Include user role
       ansible.builtin.include_role:
         name: infra.ah_configuration.user


### PR DESCRIPTION
Ansible Hub's Group permissions will be deprecated in galaxy_collection v3.0.0. This is replaced by group's roles. See: https://github.com/ansible/galaxy_collection/pull/299, https://github.com/ansible/galaxy_collection/pull/296 and https://github.com/ansible/galaxy_collection/pull/297

AAP 2.2 is EoL I think and since 2.3 there is a new role called group_roles that allow to set a list of roles on a list of groups.
So I guess we can now use this new role. This PR aim to do that.