### PR TITLE
Add a way to import EE from remote registries

### DIFF
--- a/group_vars/all/ah_ee_images.yml
+++ b/group_vars/all/ah_ee_images.yml
@@ -1,7 +1,7 @@
 ---
 # Documentation:
 # https://github.com/ansible/galaxy_collection/blob/devel/roles/ee_image/README.md
-# ah_ee_images:
+ah_ee_images: []
 #   - name:
 #     state: "{{ target_state }}"
 #     append: false

--- a/group_vars/all/ah_ee_images.yml
+++ b/group_vars/all/ah_ee_images.yml
@@ -1,4 +1,6 @@
 ---
+# Documentation:
+# https://github.com/ansible/galaxy_collection/blob/devel/roles/ee_image/README.md
 # ah_ee_images:
 #   - name:
 #     state: "{{ target_state }}"

--- a/group_vars/all/ah_ee_namespaces.yml
+++ b/group_vars/all/ah_ee_namespaces.yml
@@ -1,5 +1,5 @@
 ---
-# ah_ee_namespaces:
+ah_ee_namespaces: []
 #   - name:
 #     append:
 #     groups:

--- a/group_vars/all/ah_ee_registries.yml
+++ b/group_vars/all/ah_ee_registries.yml
@@ -3,7 +3,7 @@
 # - https://github.com/ansible/galaxy_collection/blob/devel/roles/ee_registry/README.md
 # - https://github.com/ansible/galaxy_collection/blob/devel/roles/ee_registry_index/README.md
 # - https://github.com/ansible/galaxy_collection/blob/devel/roles/ee_registry_sync/README.md
-# ah_ee_registries:
+ah_ee_registries: []
 #   - name: registry_redhat_io
 #     url: https://registry.redhat.io
 #     username: "{{ rh_username }}"

--- a/group_vars/all/ah_ee_registries.yml
+++ b/group_vars/all/ah_ee_registries.yml
@@ -1,15 +1,19 @@
 ---
+# Documentations:
+# - https://github.com/ansible/galaxy_collection/blob/devel/roles/ee_registry/README.md
+# - https://github.com/ansible/galaxy_collection/blob/devel/roles/ee_registry_index/README.md
+# - https://github.com/ansible/galaxy_collection/blob/devel/roles/ee_registry_sync/README.md
 # ah_ee_registries:
-#   - name:
-#     new_name:
-#     url:
-#     username:
-#     password:
-#     tls_validation:
-#     proxy_url:
-#     proxy_username:
-#     proxy_password:
-#     download_concurrency:
-#     rate_limit:
-#     state: "{{ target_state }}"
+#   - name: registry_redhat_io
+#     url: https://registry.redhat.io
+#     username: "{{ rh_username }}"
+#     password: "{{ rh_password }}"
+#     tls_validation: true
+#     download_concurrency: 10
+#     rate_limit: 8
+#     proxy_url: ""
+#     proxy_username: ""
+#     proxy_password: ""
+#     wait: true
+#     state: present
 ...

--- a/group_vars/all/ah_ee_repositories.yml
+++ b/group_vars/all/ah_ee_repositories.yml
@@ -1,7 +1,7 @@
 ---
 # Documentation:
 # https://github.com/ansible/galaxy_collection/tree/devel/roles/ee_repository
-# ah_ee_repositories:
+ah_ee_repositories: []
 #   - name: ansible-automation-platform/ee-minimal-rhel8
 #     readme: ""  # mutex with readme_file
 #     readme_file: ""  # mutex with readme

--- a/group_vars/all/ah_ee_repositories.yml
+++ b/group_vars/all/ah_ee_repositories.yml
@@ -1,8 +1,18 @@
 ---
+# Documentation:
+# https://github.com/ansible/galaxy_collection/tree/devel/roles/ee_repository
 # ah_ee_repositories:
-#   - name:
-#     description:
-#     readme:
-#     readme_file:
-#     state: "{{ target_state }}"
+#   - name: ansible-automation-platform/ee-minimal-rhel8
+#     readme: ""  # mutex with readme_file
+#     readme_file: ""  # mutex with readme
+#     description: >-
+#       ee-minimal is an automation execution environment for Red Hat Ansible
+#       Automation Platform.
+#     registry: registry_redhat_io
+#     upstream_name: ansible-automation-platform/ee-minimal-rhel8
+#     include_tags:
+#       - 2.16.3-1
+#     exclude_tags:
+#       - latest  # https://access.redhat.com/solutions/6980874
+#     state: present
 ...

--- a/playbooks/hub_config.yml
+++ b/playbooks/hub_config.yml
@@ -29,6 +29,31 @@
           ansible.builtin.include_role:
             name: infra.ah_configuration.publish
 
+    - name: Include ee_registry role
+      ansible.builtin.include_role:
+        name: infra.ah_configuration.ee_registry
+      when: ah_ee_registries | length is not match('0')
+
+    - name: Include ee_registry_index role
+      ansible.builtin.include_role:
+        name: infra.ah_configuration.ee_registry_index
+      when: ah_ee_registries | length is not match('0')
+
+    - name: Include ee_registry_sync role
+      ansible.builtin.include_role:
+        name: infra.ah_configuration.ee_registry_sync
+      when: ah_ee_registries | length is not match('0')
+
+    - name: Include ee_repository role
+      ansible.builtin.include_role:
+        name: infra.ah_configuration.ee_repository
+      when: ah_ee_repositories | length is not match('0')
+
+    - name: Include ee_image role
+      ansible.builtin.include_role:
+        name: infra.ah_configuration.ee_image
+      when: ah_ee_images | length is not match('0')
+
     - name: Include group role
       ansible.builtin.include_role:
         name: infra.ah_configuration.group


### PR DESCRIPTION
In order to use automation hub as a builder, I needed the base image available. This is because of this bug: https://github.com/redhat-cop/ee_utilities/issues/118 that prevent me from downloading the base image from registry.redhat.io and then push the image in "{{ ah_host }}".

This pull request adds the required roles to be able to sync a remote registry image with a private automation hub.