### PR TITLE
Add missing role to make ee_repository to sync

### DIFF
--- a/playbooks/hub_config.yml
+++ b/playbooks/hub_config.yml
@@ -49,6 +49,11 @@
         name: infra.ah_configuration.ee_repository
       when: ah_ee_repositories | length is not match('0')
 
+    - name: Include ee_repository_sync role
+      ansible.builtin.include_role:
+        name: infra.ah_configuration.ee_repository_sync
+      when: ah_ee_repositories | length is not match('0')
+
     - name: Include ee_image role
       ansible.builtin.include_role:
         name: infra.ah_configuration.ee_image


### PR DESCRIPTION
I forgot to add a role in #49.
Without it, the EE nevers get any image pulled in automationhub.

(I should test dispatch)