### PR TITLE
commenting out removing default org

### DIFF
--- a/group_vars/all/organizations.yml
+++ b/group_vars/all/organizations.yml
@@ -8,6 +8,6 @@ controller_organizations_all:
       - ah_community
   # default_environment: supported
 
-  - name: Default
-    state: absent
+  # - name: Default
+  #   state: absent
 ...


### PR DESCRIPTION
commenting out removing default org to prevent accidental deletion if there are other objects already assigned to it.