### PR TITLE
Refactor build_ee.yml to remove hard-coded attributes in repository name

### DIFF
--- a/playbooks/build_ee.yml
+++ b/playbooks/build_ee.yml
@@ -19,7 +19,7 @@
                 name:
                   - ansible-builder
                   - ansible-core
-                enablerepo: ansible-automation-platform-2.4-for-rhel-8-x86_64-rpms
+                enablerepo: "ansible-automation-platform-{{ aap_setup_down_version }}-for-rhel-{{ ansible_facts['distribution_major_version'] }}-{{ ansible_facts['architecture'] }}-rpms"
                 state: present
               become: true
           rescue:


### PR DESCRIPTION
Replace hard-coded AAP version, RHEL version, and architecture in playbooks/ee_build.yml for better environment portability.

The AAP version is set with "aap_setup_down_version" from aap_install.yml under each group_vars environment. Both RHEL version and architecture are pulled from Ansible facts.

This change allows automation developers to reduce the amount of customization needed in the playbook itself in order to be useful.